### PR TITLE
Changed all log.Fatal to return errors instead

### DIFF
--- a/paragraphObjectModel.go
+++ b/paragraphObjectModel.go
@@ -3,7 +3,6 @@ package justext
 import (
 	"github.com/peterbourgon/exp-html"
 	"io"
-	"log"
 	"regexp"
 	"strings"
 	"fmt"
@@ -95,8 +94,7 @@ func paragraphObjectModel(htmlStr string) ([]*Paragraph, error) {
 				return paragraphs, nil
 			}
 			if matchToDoErrors.MatchString(fmt.Sprintf("%s", z.Err())) {
-				log.Println("ToDo Error")
-				log.Fatal(z.Err())
+				return nil, z.Err()
 			}
 			continue
 

--- a/preprocess.go
+++ b/preprocess.go
@@ -2,22 +2,21 @@ package justext
 
 import (
 	"github.com/peterbourgon/exp-html"
-	"log"
 	"regexp"
 	"strings"
 )
 
-func preprocess(htmlStr, encoding, defaultEncoding, encErrors string) *html.Node {
+func preprocess(htmlStr, encoding, defaultEncoding, encErrors string) (*html.Node, error) {
 
 	root, err := html.Parse(strings.NewReader(htmlStr))
 	if err != nil {
-		log.Fatal(err)
+		return nil, err
 	}
 
 	addKwTags(root)
 	removeElements(root, []string{"head", "script", "style"})
 
-	return root
+	return root, nil
 }
 
 type nodeIterator func(n *html.Node)

--- a/reader.go
+++ b/reader.go
@@ -5,8 +5,8 @@ import (
 	"github.com/peterbourgon/exp-html"
 	"io"
 	"io/ioutil"
-	"log"
 	"strings"
+	"errors"
 )
 
 type Reader struct {
@@ -40,14 +40,17 @@ func (r *Reader) ReadAll() ([]*Paragraph, error) {
 		return nil, err
 	}
 
-	root := preprocess(string(in), "utf-8", "utf-8", "errors")
+	root, err := preprocess(string(in), "utf-8", "utf-8", "errors")
+	if err != nil {
+		return nil, err
+	}
 	if root == nil {
-		log.Fatal("Preprocess has resulted in nil")
+		return nil, errors.New("Preprocess has resulted in nil")
 	}
 
 	htmlSource := nodesToString(root)
 	if len(htmlSource) == 0 {
-		log.Fatal("MAIN: perprocess has returned an empty string")
+		return nil, errors.New("MAIN: perprocess has returned an empty string")
 	}
 
 	p, err := paragraphObjectModel(htmlSource)
@@ -55,8 +58,7 @@ func (r *Reader) ReadAll() ([]*Paragraph, error) {
 		return nil, err
 	}
 	if p == nil {
-		log.Println(htmlSource)
-		log.Fatal("MAIN: P is nil", err)
+		return nil, errors.New("MAIN: P is nil")
 	}
 
 	classifyParagraphs(p, r.Stoplist, r.LengthLow, r.LengthHigh, r.StopwordsLow, r.StopwordsHigh, r.MaxLinkDensity, r.NoHeadings)

--- a/stoplists.go
+++ b/stoplists.go
@@ -3,7 +3,6 @@ package justext
 import (
 	"bytes"
 	"errors"
-	"log"
 	"fmt"
 	"io/ioutil"
 )
@@ -121,10 +120,10 @@ func RegisterStoplist(name string, resourceFunc ResourceFunc) {
 }
 */
 
-func ReadStoplist(filename string) map[string]bool {
+func ReadStoplist(filename string) (map[string]bool, error) {
 	data, err := ioutil.ReadFile(filename)
 	if err != nil {
-		log.Fatal(err)
+		return nil, err
 	}
 
 	db := bytes.Split(data, []uint8("\n"))
@@ -135,7 +134,7 @@ func ReadStoplist(filename string) map[string]bool {
 		list[string(val)] = true
 	}
 
-	return list
+	return list, nil
 }
 
 func GetStoplist(language string) (map[string]bool, error) {
@@ -145,7 +144,7 @@ func GetStoplist(language string) (map[string]bool, error) {
 
 	data, err := stoplists[language]()
 	if err != nil {
-		log.Fatal(err)
+		return nil, err
 	}
 	db := bytes.Split(data, []uint8("\n"))
 

--- a/writer.go
+++ b/writer.go
@@ -69,7 +69,7 @@ func (w *Writer) outputDefault(paragraphs []*Paragraph) error {
 
 	templ, err := t.Parse(string(templateData))
 	if err != nil {
-		log.Fatal(err)
+		return err
 	}
 
 	var data = struct {
@@ -104,7 +104,7 @@ func (w *Writer) outputDetailed(paragraphs []*Paragraph) error {
 
 	templ, err := t.Parse(string(templateData))
 	if err != nil {
-		log.Fatal(err)
+		return err
 	}
 
 	var data = struct {


### PR DESCRIPTION
Hi there, we're using your library as a long running application, so log.Fatal() causes our whole application to stop. This pull request changes the log.Fatal() to return errors instead.
